### PR TITLE
Squashes all R CMD CHECK warnings

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,6 @@
 ^README.Rmd$
 ^.*\.Rproj$
 ^\.Rproj\.user$
+.github/
+^README.html$
+^codemeta.json$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -10,3 +10,5 @@
 ^doc$
 ^Meta$  
 ^README.Rmd$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 doc
 Meta
 
+.Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,7 +62,7 @@ VignetteBuilder:
 Remotes: 
     dkahle/ggmap
 Encoding: UTF-8
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.2
 X-schema.org-keywords: 
     name disambiguation, 
     bibliometrics, 
@@ -75,3 +75,4 @@ X-schema.org-keywords:
     science of science,
     Web of Science
 X-schema.org-isPartOf: https://ropensci.org
+Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -76,3 +76,4 @@ X-schema.org-keywords:
     Web of Science
 X-schema.org-isPartOf: https://ropensci.org
 Roxygen: list(markdown = TRUE)
+LazyData: true

--- a/R/authors_refine.R
+++ b/R/authors_refine.R
@@ -20,7 +20,7 @@
 #' BITR_prelim_df <- BITR_authors$prelim
 #' 
 #' ## If accepting the preliminary disambiguation 
-#' ## from `authors_clean()` without review:
+#' ## from authors_clean() without review:
 #' refine_df <- authors_refine(BITR_review_df, BITR_prelim_df,
 #'     sim_score = 0.90, confidence = 5)
 #' 

--- a/R/plot_addresses_country.R
+++ b/R/plot_addresses_country.R
@@ -3,10 +3,11 @@
 #' This function plots an addresses data.frame 
 #' object by country name.
 #'
-#' @param data address element from the output from the `authors_georef()`` 
+#' @param data address element from the output from the `authors_georef()` 
 #' function, containing geocoded address latitude and longitude locations.
 #' @param mapRegion what portion of the world map to show. possible values 
-#' include ["world","North America","South America","Australia","Africa","Antarctica","Eurasia"]
+#' include `"world"`, `"North America"`, `"South America"`, `"Australia"`,
+#' `"Africa"`, `"Antarctica"`, and `"Eurasia"`
 #' 
 #' @examples 
 #' 

--- a/R/plot_addresses_points.R
+++ b/R/plot_addresses_points.R
@@ -8,7 +8,7 @@
 #' latitude and longitude locations.
 #' @param mapCountry What country to map. Possible values 
 #' include ["USA", "Brazil", "Australia", "UK"]
-#' use \code{data(countries) to see possible names}. No value defaults
+#' use `data(countries)` to see possible names. No value defaults
 #'  to the world map.
 #' 
 #' @examples

--- a/R/plot_addresses_points.R
+++ b/R/plot_addresses_points.R
@@ -7,7 +7,7 @@
 #' the `authors_georef()`` function, containing geocoded address 
 #' latitude and longitude locations.
 #' @param mapCountry What country to map. Possible values 
-#' include ["USA", "Brazil", "Australia", "UK"]
+#' include `"USA"`, `"Brazil"`, `"Australia",` and `"UK"`
 #' use `data(countries)` to see possible names. No value defaults
 #'  to the world map.
 #' 

--- a/R/plot_net_address.R
+++ b/R/plot_net_address.R
@@ -1,15 +1,20 @@
-#' Creates a network diagram of coauthors' addresses linked by reference, 
-#' and with nodes arranged geographically
+#' Creates a network diagram of coauthors' addresses linked by reference, and
+#' with nodes arranged geographically
 #'
-#'  This function takes an addresses data.frame,
-#'  links it to an authors__references dataset and plots a network diagram 
-#'  generated for individual points of co-authorship.
+#' This function takes an addresses data.frame, links it to an
+#' authors__references dataset and plots a network diagram generated for
+#' individual points of co-authorship.
 #'
-#' @param data the `address` element from the list outputted from the `authors_georef()`` function, containing geocoded address latitude and longitude locations.
-#' @param mapRegion what portion of the world map to show. possible values include ["world","North America","South America","Australia","Africa","Antarctica","Eurasia"]
-#' @param lineResolution the resolution of the lines drawn, higher numbers will make smoother curves
-#' default is 10. 
-#' @param lineAlpha transparency of the lines, fed into ggplots alpha value. Number between 0 - 1.
+#' @param data the `address` element from the list outputted from the
+#'   `authors_georef()` function, containing geocoded address latitude and
+#'   longitude locations.
+#' @param mapRegion what portion of the world map to show. possible values
+#'   include `"world"`, `"North America"`, `"South America"`, `"Australia"`,
+#'   `"Africa"`, `"Antarctica"`, `"Eurasia"`
+#' @param lineResolution the resolution of the lines drawn, higher numbers will
+#'   make smoother curves default is 10.
+#' @param lineAlpha transparency of the lines, fed into ggplots alpha value.
+#'   Number between 0 - 1.
 #' @examples 
 #' ## Using the output of authors_georef (e.g., BITR_geocode)
 #' data(BITR_geocode)

--- a/R/plot_net_country.R
+++ b/R/plot_net_country.R
@@ -1,18 +1,20 @@
-#' Creates a network diagram of coauthors' countries linked by reference, 
-#' #and with nodes arranged geographically
+#' Creates a network diagram of coauthors' countries linked by reference, #and
+#' with nodes arranged geographically
 #'
-#' This function takes an addresses data.frame, 
-#' #links it to an authors_references dataset and plots a network diagram 
-#' generated for countries of co-authorship.
+#' This function takes an addresses data.frame, links it to an
+#' authors_references dataset and plots a network diagram generated for
+#' countries of co-authorship.
 #'
-#' @param data the `address` element from the list outputted from 
-#' the `authors_georef()`` function, containing geocoded address 
-#' latitude and longitude locations.
-#' @param mapRegion what portion of the world map to show. possible 
-#' values include ["world","North America","South America","Australia","Africa","Antarctica","Eurasia"]
-#' @param lineResolution the resolution of the lines drawn, higher numbers will make smoother curves
-#' default is 10. 
-#' @param lineAlpha transparency of the lines, fed into ggplots alpha value. Number between 0 - 1.
+#' @param data the `address` element from the list outputted from the
+#'   `authors_georef()` function, containing geocoded address latitude and
+#'   longitude locations.
+#' @param mapRegion what portion of the world map to show. possible values
+#'   include `"world"`, `"North America"`, `"South America"`, `"Australia"`,
+#'   `"Africa"`, `"Antarctica"`, and `"Eurasia"`
+#' @param lineResolution the resolution of the lines drawn, higher numbers will
+#'   make smoother curves default is 10.
+#' @param lineAlpha transparency of the lines, fed into ggplots alpha value.
+#'   Number between 0 - 1.
 #' @examples 
 #' ## Using the output of authors_georef (e.g., BITR_geocode)
 #' data(BITR_geocode)

--- a/man/BITR.Rd
+++ b/man/BITR.Rd
@@ -4,48 +4,50 @@
 \name{BITR}
 \alias{BITR}
 \title{Data from the journal BioTropica (pulled from Web of Knowledge)}
-\format{A data frame with 10 rows and 32 variables:
+\format{
+A data frame with 10 rows and 32 variables:
 \describe{
-  \item{filename}{the original filename the text was created from}
-  \item{refID}{the unique identifier given to each reference article by references_read()}
-  \item{AB}{Abstract}
-  \item{AF}{Full Names}
-  \item{AU}{Abbreviated names}
-  \item{C1}{Addresses}
-  \item{EM}{emails}
-  \item{RI}{Web of Science ID}
-  \item{OI}{OrcID}
-  \item{RP}{Reprint Address}
-  \item{TI}{Title}
-  \item{UT}{Web of Knowledge Unique ID}
-  \item{BP}{See url below}
-  \item{CR}{See url below}
-  \item{DE}{See url below}
-  \item{DI}{See url below}
-  \item{EP}{See url below}
-  \item{FN}{See url below}
-  \item{FU}{See url below}
-  \item{PD}{See url below}
-  \item{PG}{See url below}
-  \item{PT}{See url below}
-  \item{PU}{See url below}
-  \item{PY}{See url below}
-  \item{PM}{See url below}
-  \item{SC}{See url below}
-  \item{SN}{See url below}
-  \item{SO}{See url below}
-  \item{TC}{See url below}
-  \item{VL}{See url below}
-  \item{WC}{See url below}
-  \item{Z9}{See url below}
+\item{filename}{the original filename the text was created from}
+\item{refID}{the unique identifier given to each reference article by references_read()}
+\item{AB}{Abstract}
+\item{AF}{Full Names}
+\item{AU}{Abbreviated names}
+\item{C1}{Addresses}
+\item{EM}{emails}
+\item{RI}{Web of Science ID}
+\item{OI}{OrcID}
+\item{RP}{Reprint Address}
+\item{TI}{Title}
+\item{UT}{Web of Knowledge Unique ID}
+\item{BP}{See url below}
+\item{CR}{See url below}
+\item{DE}{See url below}
+\item{DI}{See url below}
+\item{EP}{See url below}
+\item{FN}{See url below}
+\item{FU}{See url below}
+\item{PD}{See url below}
+\item{PG}{See url below}
+\item{PT}{See url below}
+\item{PU}{See url below}
+\item{PY}{See url below}
+\item{PM}{See url below}
+\item{SC}{See url below}
+\item{SN}{See url below}
+\item{SO}{See url below}
+\item{TC}{See url below}
+\item{VL}{See url below}
+\item{WC}{See url below}
+\item{Z9}{See url below}
 The remaining codes are described on the Web of Knowledge website:
 \url{https://images.webofknowledge.com/images/help/WOS/hs_wos_fieldtags.html}
-}}
+}
+}
 \usage{
 BITR
 }
 \description{
-A dataset containing 10 articles taken from the BioTropica journal. 
+A dataset containing 10 articles taken from the BioTropica journal.
 This dataset represents the typical formatted output from \code{references_read()}
 in the refsplitr package. It serves as a testbed for commonly miscategorized names
 }

--- a/man/BITR_geocode.Rd
+++ b/man/BITR_geocode.Rd
@@ -4,36 +4,38 @@
 \name{BITR_geocode}
 \alias{BITR_geocode}
 \title{Georeferenced data from the journal BioTropica (pulled from Web of Science)}
-\format{A data frame with 41 rows and 15 variables:
+\format{
+A data frame with 41 rows and 15 variables:
 \describe{
-  \item{authorID}{ID field populated in authors_clean}
-  \item{university}{also can be considered 
-  institution for non-universities}
-  \item{postal_code}{character, international postcode}
-  \item{country}{country name}
-  \item{lat}{numeric, latitude populated from authors_georef}
-  \item{lon}{numeric, longitude populated from authors_georef}
-  \item{groupID}{ID field for what name group the author 
-  is identied as from authors_clean()}
-  \item{author_order}{numeric, order of author from jounral article}
-  \item{address}{address of references pulled from 
-  the original raw WOS file}
-  \item{department}{department which is nested within university}
-  \item{RP_address}{reprint address, pulled from the original raw WOS file}
-  \item{RI}{ResearcherID number, identifier given by 
-  web of science only, less common than OrcID}
-  \item{OI}{OrcID, unique identifier for 
-  researcher given by https://orcid.org }
-  \item{UT}{unique identifier to each article, given by WOS}
-  \item{refID}{unique identifier for each article, 
-  given by references_read()}
-}}
+\item{authorID}{ID field populated in authors_clean}
+\item{university}{also can be considered
+institution for non-universities}
+\item{postal_code}{character, international postcode}
+\item{country}{country name}
+\item{lat}{numeric, latitude populated from authors_georef}
+\item{lon}{numeric, longitude populated from authors_georef}
+\item{groupID}{ID field for what name group the author
+is identied as from authors_clean()}
+\item{author_order}{numeric, order of author from jounral article}
+\item{address}{address of references pulled from
+the original raw WOS file}
+\item{department}{department which is nested within university}
+\item{RP_address}{reprint address, pulled from the original raw WOS file}
+\item{RI}{ResearcherID number, identifier given by
+web of science only, less common than OrcID}
+\item{OI}{OrcID, unique identifier for
+researcher given by https://orcid.org }
+\item{UT}{unique identifier to each article, given by WOS}
+\item{refID}{unique identifier for each article,
+given by references_read()}
+}
+}
 \usage{
 BITR_geocode
 }
 \description{
-A dataset containing 41 authors taken from the BioTropica journal. 
-This dataset represents the typical formatted output 
+A dataset containing 41 authors taken from the BioTropica journal.
+This dataset represents the typical formatted output
 from \code{authors_georef()}
 in the refsplitr package. It serves as a useful testing data set for
 spatial functions and

--- a/man/authors_clean.Rd
+++ b/man/authors_clean.Rd
@@ -11,18 +11,18 @@ authors_clean(references)
 }
 \description{
 \code{authors_clean} This function takes the output from
- \code{references_read} and cleans the author information.
+\code{references_read} and cleans the author information.
 }
 \details{
 Information on addresses, emails, ORCIDs, etc are matched.
 
-It then attempts to match same author entries together into likely author 
+It then attempts to match same author entries together into likely author
 groups based on common full names, addresses, emails, ORCIDs etc.
 
-Records that are not matched this way have a Jaro-Winkler similiarty 
+Records that are not matched this way have a Jaro-Winkler similiarty
 analysis metric calculated for all possible matching author names.
 
-This calculates the amount of character similarities 
+This calculates the amount of character similarities
 based on distance of similar character.
 }
 \examples{

--- a/man/authors_georef.Rd
+++ b/man/authors_georef.Rd
@@ -7,17 +7,17 @@
 authors_georef(data, address_column = "address")
 }
 \arguments{
-\item{data}{dataframe from `authors_refine()`}
+\item{data}{dataframe from \code{authors_refine()}}
 
 \item{address_column}{name of column in quotes where the addresses are}
 }
 \description{
-\code{authors_georef} This function takes the final author list from 
-refine_authors, and calculates the lat long of the addresses. 
-It does this by feeding the addresses into data science toolkit. 
+\code{authors_georef} This function takes the final author list from
+refine_authors, and calculates the lat long of the addresses.
+It does this by feeding the addresses into data science toolkit.
 In order to maximize effectiveness and mitigate errors in parsing addresses
 We run this multiple times creating addresses in different ways
-in hopes that the data science toolkit can recognize an address
+in hopes that the google georeferencing API can recognize an address
 1st. University, city, zipcode, country
 2nd. City, zipcode, country
 3rd. city, country
@@ -25,7 +25,7 @@ in hopes that the data science toolkit can recognize an address
 }
 \details{
 The output is a list with three data.frames
-\code{addresses} is a data frame with all information from 
+\code{addresses} is a data frame with all information from
 refine_authors plus new location columns and calculated lat longs.
 \code{missing addresses} is a data frame with all addresses could
 not be geocoded

--- a/man/authors_refine.Rd
+++ b/man/authors_refine.Rd
@@ -7,18 +7,18 @@
 authors_refine(review, prelim, sim_score = NULL, confidence = NULL)
 }
 \arguments{
-\item{review}{the `review` element from list output by \code{authors_clean}}
+\item{review}{the \code{review} element from list output by \code{authors_clean}}
 
-\item{prelim}{the `prelim` element from list output by \code{authors_clean}}
+\item{prelim}{the \code{prelim} element from list output by \code{authors_clean}}
 
 \item{sim_score}{similarity score cut off point. Number from 0-1.}
 
 \item{confidence}{confidence score cut off point. Number from 0 - 10.}
 }
 \description{
-\code{authors_refine} This function takes the author list output after the 
-output has been synthesized for incorrect author matches. It contains a 
-similarity score cutoff like read_authors. This however is to further 
+\code{authors_refine} This function takes the author list output after the
+output has been synthesized for incorrect author matches. It contains a
+similarity score cutoff like read_authors. This however is to further
 constrain the list. New values ARE NOT created, instead it filters by the
 sim_score column in the output file.
 }
@@ -30,7 +30,7 @@ BITR_review_df <- BITR_authors$review
 BITR_prelim_df <- BITR_authors$prelim
 
 ## If accepting the preliminary disambiguation 
-from authors_clean without review:
+## from authors_clean() without review:
 refine_df <- authors_refine(BITR_review_df, BITR_prelim_df,
     sim_score = 0.90, confidence = 5)
 

--- a/man/countries.Rd
+++ b/man/countries.Rd
@@ -4,12 +4,14 @@
 \name{countries}
 \alias{countries}
 \title{Names of all the countries in the world}
-\format{a character vector of country names
+\format{
+a character vector of country names
 \describe{
-  \item{countries}{a character vector of country names}
-  }
-  @export countries
-  @noRd}
+\item{countries}{a character vector of country names}
+}
+@export countries
+@noRd
+}
 \usage{
 countries
 }

--- a/man/plot_addresses_country.Rd
+++ b/man/plot_addresses_country.Rd
@@ -7,11 +7,12 @@
 plot_addresses_country(data, mapRegion = "world")
 }
 \arguments{
-\item{data}{address element from the output from the `authors_georef()``
+\item{data}{address element from the output from the \code{authors_georef()}
 function, containing geocoded address latitude and longitude locations.}
 
 \item{mapRegion}{what portion of the world map to show. possible values
-include \link{"world","North America","South America","Australia","Africa","Antarctica","Eurasia"}}
+include \code{"world"}, \code{"North America"}, \code{"South America"}, \code{"Australia"},
+\code{"Africa"}, \code{"Antarctica"}, and \code{"Eurasia"}}
 }
 \description{
 This function plots an addresses data.frame

--- a/man/plot_addresses_country.Rd
+++ b/man/plot_addresses_country.Rd
@@ -7,14 +7,14 @@
 plot_addresses_country(data, mapRegion = "world")
 }
 \arguments{
-\item{data}{address element from the output from the `authors_georef()`` 
+\item{data}{address element from the output from the `authors_georef()``
 function, containing geocoded address latitude and longitude locations.}
 
-\item{mapRegion}{what portion of the world map to show. possible values 
-include ["world","North America","South America","Australia","Africa","Antarctica","Eurasia"]}
+\item{mapRegion}{what portion of the world map to show. possible values
+include \link{"world","North America","South America","Australia","Africa","Antarctica","Eurasia"}}
 }
 \description{
-This function plots an addresses data.frame 
+This function plots an addresses data.frame
 object by country name.
 }
 \examples{

--- a/man/plot_addresses_points.Rd
+++ b/man/plot_addresses_points.Rd
@@ -7,17 +7,17 @@
 plot_addresses_points(data, mapCountry = NULL)
 }
 \arguments{
-\item{data}{the `address` element from the list output by 
-the `authors_georef()`` function, containing geocoded address 
+\item{data}{the \code{address} element from the list output by
+the `authors_georef()`` function, containing geocoded address
 latitude and longitude locations.}
 
-\item{mapCountry}{What country to map. Possible values 
-include ["USA", "Brazil", "Australia", "UK"]
+\item{mapCountry}{What country to map. Possible values
+include \link{"USA", "Brazil", "Australia", "UK"}
 use \code{data(countries) to see possible names}. No value defaults
- to the world map.}
+to the world map.}
 }
 \description{
-This function plots an addresses data.frame 
+This function plots an addresses data.frame
 object by point overlaid on the countries of the world.
 }
 \examples{

--- a/man/plot_addresses_points.Rd
+++ b/man/plot_addresses_points.Rd
@@ -13,7 +13,7 @@ latitude and longitude locations.}
 
 \item{mapCountry}{What country to map. Possible values
 include \link{"USA", "Brazil", "Australia", "UK"}
-use \code{data(countries) to see possible names}. No value defaults
+use \code{data(countries)} to see possible names. No value defaults
 to the world map.}
 }
 \description{

--- a/man/plot_addresses_points.Rd
+++ b/man/plot_addresses_points.Rd
@@ -12,7 +12,7 @@ the `authors_georef()`` function, containing geocoded address
 latitude and longitude locations.}
 
 \item{mapCountry}{What country to map. Possible values
-include \link{"USA", "Brazil", "Australia", "UK"}
+include \code{"USA"}, \code{"Brazil"}, \verb{"Australia",} and \code{"UK"}
 use \code{data(countries)} to see possible names. No value defaults
 to the world map.}
 }

--- a/man/plot_net_address.Rd
+++ b/man/plot_net_address.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/plot_net_address.R
 \name{plot_net_address}
 \alias{plot_net_address}
-\title{Creates a network diagram of coauthors' addresses linked by reference, 
+\title{Creates a network diagram of coauthors' addresses linked by reference,
 and with nodes arranged geographically}
 \usage{
 plot_net_address(
@@ -13,9 +13,9 @@ plot_net_address(
 )
 }
 \arguments{
-\item{data}{the `address` element from the list outputted from the `authors_georef()`` function, containing geocoded address latitude and longitude locations.}
+\item{data}{the \code{address} element from the list outputted from the `authors_georef()`` function, containing geocoded address latitude and longitude locations.}
 
-\item{mapRegion}{what portion of the world map to show. possible values include ["world","North America","South America","Australia","Africa","Antarctica","Eurasia"]}
+\item{mapRegion}{what portion of the world map to show. possible values include \link{"world","North America","South America","Australia","Africa","Antarctica","Eurasia"}}
 
 \item{lineResolution}{the resolution of the lines drawn, higher numbers will make smoother curves
 default is 10.}
@@ -24,8 +24,8 @@ default is 10.}
 }
 \description{
 This function takes an addresses data.frame,
- links it to an authors__references dataset and plots a network diagram 
- generated for individual points of co-authorship.
+links it to an authors__references dataset and plots a network diagram
+generated for individual points of co-authorship.
 }
 \examples{
 ## Using the output of authors_georef (e.g., BITR_geocode)

--- a/man/plot_net_address.Rd
+++ b/man/plot_net_address.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/plot_net_address.R
 \name{plot_net_address}
 \alias{plot_net_address}
-\title{Creates a network diagram of coauthors' addresses linked by reference,
-and with nodes arranged geographically}
+\title{Creates a network diagram of coauthors' addresses linked by reference, and
+with nodes arranged geographically}
 \usage{
 plot_net_address(
   data,
@@ -13,19 +13,24 @@ plot_net_address(
 )
 }
 \arguments{
-\item{data}{the \code{address} element from the list outputted from the `authors_georef()`` function, containing geocoded address latitude and longitude locations.}
+\item{data}{the \code{address} element from the list outputted from the
+\code{authors_georef()} function, containing geocoded address latitude and
+longitude locations.}
 
-\item{mapRegion}{what portion of the world map to show. possible values include \link{"world","North America","South America","Australia","Africa","Antarctica","Eurasia"}}
+\item{mapRegion}{what portion of the world map to show. possible values
+include \code{"world"}, \code{"North America"}, \code{"South America"}, \code{"Australia"},
+\code{"Africa"}, \code{"Antarctica"}, \code{"Eurasia"}}
 
-\item{lineResolution}{the resolution of the lines drawn, higher numbers will make smoother curves
-default is 10.}
+\item{lineResolution}{the resolution of the lines drawn, higher numbers will
+make smoother curves default is 10.}
 
-\item{lineAlpha}{transparency of the lines, fed into ggplots alpha value. Number between 0 - 1.}
+\item{lineAlpha}{transparency of the lines, fed into ggplots alpha value.
+Number between 0 - 1.}
 }
 \description{
-This function takes an addresses data.frame,
-links it to an authors__references dataset and plots a network diagram
-generated for individual points of co-authorship.
+This function takes an addresses data.frame, links it to an
+authors__references dataset and plots a network diagram generated for
+individual points of co-authorship.
 }
 \examples{
 ## Using the output of authors_georef (e.g., BITR_geocode)

--- a/man/plot_net_coauthor.Rd
+++ b/man/plot_net_coauthor.Rd
@@ -3,21 +3,21 @@
 \name{plot_net_coauthor}
 \alias{plot_net_coauthor}
 \title{Creates a network diagram of coauthors' countries linked by reference
-This function takes an addresses data.frame, 
-links it to an authors_references dataset and plots a network diagram 
+This function takes an addresses data.frame,
+links it to an authors_references dataset and plots a network diagram
 generated for co-authorship.}
 \usage{
 plot_net_coauthor(data)
 }
 \arguments{
-\item{data}{the `address` element from the list outputted from 
-the `authors_georef()`` function, containing geocoded address 
+\item{data}{the \code{address} element from the list outputted from
+the `authors_georef()`` function, containing geocoded address
 latitude and longitude locations.}
 }
 \description{
 Creates a network diagram of coauthors' countries linked by reference
-This function takes an addresses data.frame, 
-links it to an authors_references dataset and plots a network diagram 
+This function takes an addresses data.frame,
+links it to an authors_references dataset and plots a network diagram
 generated for co-authorship.
 }
 \examples{

--- a/man/plot_net_country.Rd
+++ b/man/plot_net_country.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/plot_net_country.R
 \name{plot_net_country}
 \alias{plot_net_country}
-\title{Creates a network diagram of coauthors' countries linked by reference, 
+\title{Creates a network diagram of coauthors' countries linked by reference,
 #and with nodes arranged geographically}
 \usage{
 plot_net_country(
@@ -13,21 +13,21 @@ plot_net_country(
 )
 }
 \arguments{
-\item{data}{the `address` element from the list outputted from 
-the `authors_georef()`` function, containing geocoded address 
+\item{data}{the \code{address} element from the list outputted from
+the `authors_georef()`` function, containing geocoded address
 latitude and longitude locations.}
 
 \item{lineResolution}{the resolution of the lines drawn, higher numbers will make smoother curves
 default is 10.}
 
-\item{mapRegion}{what portion of the world map to show. possible 
-values include ["world","North America","South America","Australia","Africa","Antarctica","Eurasia"]}
+\item{mapRegion}{what portion of the world map to show. possible
+values include \link{"world","North America","South America","Australia","Africa","Antarctica","Eurasia"}}
 
 \item{lineAlpha}{transparency of the lines, fed into ggplots alpha value. Number between 0 - 1.}
 }
 \description{
-This function takes an addresses data.frame, 
-#links it to an authors_references dataset and plots a network diagram 
+This function takes an addresses data.frame,
+#links it to an authors_references dataset and plots a network diagram
 generated for countries of co-authorship.
 }
 \examples{

--- a/man/plot_net_country.Rd
+++ b/man/plot_net_country.Rd
@@ -2,8 +2,8 @@
 % Please edit documentation in R/plot_net_country.R
 \name{plot_net_country}
 \alias{plot_net_country}
-\title{Creates a network diagram of coauthors' countries linked by reference,
-#and with nodes arranged geographically}
+\title{Creates a network diagram of coauthors' countries linked by reference, #and
+with nodes arranged geographically}
 \usage{
 plot_net_country(
   data,
@@ -13,22 +13,24 @@ plot_net_country(
 )
 }
 \arguments{
-\item{data}{the \code{address} element from the list outputted from
-the `authors_georef()`` function, containing geocoded address
-latitude and longitude locations.}
+\item{data}{the \code{address} element from the list outputted from the
+\code{authors_georef()} function, containing geocoded address latitude and
+longitude locations.}
 
-\item{lineResolution}{the resolution of the lines drawn, higher numbers will make smoother curves
-default is 10.}
+\item{lineResolution}{the resolution of the lines drawn, higher numbers will
+make smoother curves default is 10.}
 
-\item{mapRegion}{what portion of the world map to show. possible
-values include \link{"world","North America","South America","Australia","Africa","Antarctica","Eurasia"}}
+\item{mapRegion}{what portion of the world map to show. possible values
+include \code{"world"}, \code{"North America"}, \code{"South America"}, \code{"Australia"},
+\code{"Africa"}, \code{"Antarctica"}, and \code{"Eurasia"}}
 
-\item{lineAlpha}{transparency of the lines, fed into ggplots alpha value. Number between 0 - 1.}
+\item{lineAlpha}{transparency of the lines, fed into ggplots alpha value.
+Number between 0 - 1.}
 }
 \description{
-This function takes an addresses data.frame,
-#links it to an authors_references dataset and plots a network diagram
-generated for countries of co-authorship.
+This function takes an addresses data.frame, links it to an
+authors_references dataset and plots a network diagram generated for
+countries of co-authorship.
 }
 \examples{
 ## Using the output of authors_georef (e.g., BITR_geocode)

--- a/man/references_read.Rd
+++ b/man/references_read.Rd
@@ -7,23 +7,23 @@
 references_read(data = ".", dir = FALSE, include_all = FALSE)
 }
 \arguments{
-\item{data}{the location of the file or files to be imported. This can be either the absolute or 
-relative name of the file (for a single file) or folder (for multiple files stored in the same folder; 
+\item{data}{the location of the file or files to be imported. This can be either the absolute or
+relative name of the file (for a single file) or folder (for multiple files stored in the same folder;
 used in conjuction with `dir = TRUE``). If left blank it is assumed the location is the working directory.}
 
-\item{dir}{if FALSE it is assumed a single file is to be imported. 
-Set to TRUE if importing multiple files (the path to the folder in which files are stored is set with `data=``; 
+\item{dir}{if FALSE it is assumed a single file is to be imported.
+Set to TRUE if importing multiple files (the path to the folder in which files are stored is set with `data=``;
 all files in the folder will be imported). Defaults to FALSE.}
 
-\item{include_all}{if FALSE only a subset of commonly used fields from references records are imported. 
-If TRUE then all fields from the reference records are imported. Defaults to FALSE.  
-The additional data fields included if `include_all=TRUE`: CC, CH, CL, CT, CY, DT, FX, GA, GE, ID, IS, J9, JI, 
+\item{include_all}{if FALSE only a subset of commonly used fields from references records are imported.
+If TRUE then all fields from the reference records are imported. Defaults to FALSE.
+The additional data fields included if \code{include_all=TRUE}: CC, CH, CL, CT, CY, DT, FX, GA, GE, ID, IS, J9, JI,
 LA, LT, MC, MI, NR, PA, PI, PN, PS, RID, SU, TA, VR.}
 }
 \description{
 \code{references_read} This function reads Thomson Reuters Web of Knowledge
 and ISI format reference data files into an R-friendly data format. The resulting dataframe
-is the argument for the refplitr function `authors_clean()`.
+is the argument for the refplitr function \code{authors_clean()}.
 }
 \examples{
 ## If a single files is being imported from a folder called "data" located in an RStudio Project: 


### PR DESCRIPTION
Did some work to remove all warnings on `devtools::check()`.  There are still the two failing tests though.

Things I did:
1. ran `usethis::use_roxygen_md` to get markdown in documentation working
2. added `LazyData: true` to description to fix some warnings (see: https://stackoverflow.com/questions/57396392/warning-variables-with-usage-in-documentation-object-fang-but-not-in-code)
3. removed square brackets from docs that were getting read as links (because I turned on markdown, oops)
4. added some files to .Rbuildignore